### PR TITLE
Fix: duplicate versions

### DIFF
--- a/libexec/kzenv-list-remote
+++ b/libexec/kzenv-list-remote
@@ -18,5 +18,6 @@ curlw -sf "${KZENV_REMOTE_API}"| \
   grep -v pluginator| \
   grep -v api| \
   grep -v pseudo| \
-  grep -o -E "[0-9]+\.[0-9]+\.[0-9]+"
+  grep -o -E "[0-9]+\.[0-9]+\.[0-9]+" |
+  uniq
 echo -e "1.0.11\n1.0.10\n1.0.9\n1.0.8\n1.0.7\n1.0.6\n1.0.5\n1.0.4\n1.0.3\n1.0.2\n1.0.1"


### PR DESCRIPTION
Fix #8 

```bash
$ ./bin/kzenv list-remote
3.5.4
3.5.3
3.5.2
3.5.1
3.4.0
3.3.0
3.2.3
3.2.2
3.2.1
3.2.0
3.1.0
3.0.3
3.0.2
3.0.1
3.0.0
2.1.0
2.0.3
2.0.2
1.0.11
1.0.10
1.0.9
1.0.8
1.0.7
1.0.6
1.0.5
1.0.4
1.0.3
1.0.2
1.0.1
```
